### PR TITLE
Cherry-pick'ed changes from hotfix/block-txes-info-api-fixes

### DIFF
--- a/packages/api/block.go
+++ b/packages/api/block.go
@@ -53,14 +53,15 @@ func getBlockInfo(w http.ResponseWriter, r *http.Request, data *apiData, logger 
 		return errorAPI(w, `E_NOTFOUND`, http.StatusNotFound)
 	}
 	data.result = &getBlockInfoResult{Hash: block.Hash, EcosystemID: block.EcosystemID, KeyID: block.KeyID, Time: block.Time, Tx: block.Tx, RollbacksHash: block.RollbacksHash}
+	log.WithFields(log.Fields{"id": blockID, "hash": block.Hash, "ecosystem_id": block.EcosystemID, "key_id": block.KeyID, "time": block.Time, "tx": block.Tx, "rollbacks_hash": block.RollbacksHash}).Debug("Block Information")
 	return nil
 }
 
 type TxInfo struct {
-	Hash         string
-	ContractName string
-	Params       map[string]interface{}
-	KeyID        int64
+	Hash         []byte                 `json:"hash"`
+	ContractName string                 `json:"contract_name"`
+	Params       map[string]interface{} `json:"params"`
+	KeyID        int64                  `json:"key_id"`
 }
 
 func getBlocksTxInfo(w http.ResponseWriter, r *http.Request, data *apiData, logger *log.Entry) error {
@@ -92,7 +93,7 @@ func getBlocksTxInfo(w http.ResponseWriter, r *http.Request, data *apiData, logg
 		txInfoCollection := make([]TxInfo, 0, len(blck.Transactions))
 		for _, tx := range blck.Transactions {
 			txInfo := TxInfo{
-				Hash: string(tx.TxHash),
+				Hash: tx.TxHash,
 			}
 
 			if tx.TxContract != nil {
@@ -107,9 +108,127 @@ func getBlocksTxInfo(w http.ResponseWriter, r *http.Request, data *apiData, logg
 			}
 
 			txInfoCollection = append(txInfoCollection, txInfo)
+
+			log.WithFields(log.Fields{"block_id": blockModel.ID, "tx hash": txInfo.Hash, "contract_name": txInfo.ContractName, "key_id": txInfo.KeyID, "params": txInfoCollection}).Debug("Block Transactions Information")
 		}
 
 		result[blockModel.ID] = txInfoCollection
+	}
+
+	data.result = result
+	return nil
+}
+
+type TxDetailedInfo struct {
+	Hash         []byte                 `json:"hash"`
+	ContractName string                 `json:"contract_name"`
+	Params       map[string]interface{} `json:"params"`
+	KeyID        int64                  `json:"key_id"`
+	Time         int64                  `json:"time"`
+	Type         int64                  `json:"type"`
+}
+
+type BlockHeaderInfo struct {
+	BlockID      int64  `json:"block_id"`
+	Time         int64  `json:"time"`
+	EcosystemID  int64  `json:"ecosystem_id"`
+	KeyID        int64  `json:"key_id"`
+	NodePosition int64  `json:"node_position"`
+	Sign         []byte `json:"sign"`
+	Hash         []byte `json:"hash"`
+	Version      int    `json:"version"`
+}
+
+type BlockDetailedInfo struct {
+	Header        BlockHeaderInfo  `json:"header"`
+	Hash          []byte           `json:"hash"`
+	EcosystemID   int64            `json:"ecosystem_id"`
+	NodePosition  int64            `json:"node_position"`
+	KeyID         int64            `json:"key_id"`
+	Time          int64            `json:"time"`
+	Tx            int32            `json:"tx_count"`
+	RollbacksHash []byte           `json:"rollbacks_hash"`
+	MrklRoot      []byte           `json:"mrkl_root"`
+	BinData       []byte           `json:"bin_data"`
+	SysUpdate     bool             `json:"sys_update"`
+	GenBlock      bool             `json:"gen_block"`
+	StopCount     int              `json:"stop_count"`
+	Transactions  []TxDetailedInfo `json:"transactions"`
+}
+
+func getBlocksDetailedInfo(w http.ResponseWriter, r *http.Request, data *apiData, logger *log.Entry) error {
+	startBlockID := data.params["block_id"].(int64)
+	if startBlockID > 0 {
+		startBlockID--
+	}
+
+	blocksCount := data.params["count"].(int64)
+
+	blocks, err := model.GetBlockchain(startBlockID, startBlockID+blocksCount)
+	if err != nil {
+		log.WithFields(log.Fields{"type": consts.DBError, "error": err}).Error("on getting blocks range")
+		return errorAPI(w, err, http.StatusInternalServerError)
+	}
+
+	if len(blocks) == 0 {
+		return errorAPI(w, "E_NOTFOUND", http.StatusNotFound)
+	}
+
+	result := map[int64]BlockDetailedInfo{}
+	for _, blockModel := range blocks {
+		blck, err := block.UnmarshallBlock(bytes.NewBuffer(blockModel.Data), blockModel.ID == 1)
+		if err != nil {
+			log.WithFields(log.Fields{"type": consts.UnmarshallingError, "error": err, "bolck_id": blockModel.ID}).Error("on unmarshalling block")
+			return errorAPI(w, err, http.StatusInternalServerError)
+		}
+
+		txDetailedInfoCollection := make([]TxDetailedInfo, 0, len(blck.Transactions))
+		for _, tx := range blck.Transactions {
+			txDetailedInfo := TxDetailedInfo{
+				Hash: tx.TxHash,
+			}
+
+			if tx.TxContract != nil {
+				txDetailedInfo.ContractName = tx.TxContract.Name
+				txDetailedInfo.Params = tx.TxData
+				txDetailedInfo.KeyID = tx.TxKeyID
+				txDetailedInfo.Time = tx.TxTime
+				txDetailedInfo.Type = tx.TxType
+			}
+
+			txDetailedInfoCollection = append(txDetailedInfoCollection, txDetailedInfo)
+
+			log.WithFields(log.Fields{"block_id": blockModel.ID, "tx hash": txDetailedInfo.Hash, "contract_name": txDetailedInfo.ContractName, "key_id": txDetailedInfo.KeyID, "time": txDetailedInfo.Time, "type": txDetailedInfo.Type, "params": txDetailedInfoCollection}).Debug("Block Transactions Information")
+		}
+
+		header := BlockHeaderInfo{
+			BlockID:      blck.Header.BlockID,
+			Time:         blck.Header.Time,
+			EcosystemID:  blck.Header.EcosystemID,
+			KeyID:        blck.Header.KeyID,
+			NodePosition: blck.Header.NodePosition,
+			Sign:         blck.Header.Sign,
+			Hash:         blck.Header.Hash,
+			Version:      blck.Header.Version,
+		}
+
+		bdi := BlockDetailedInfo{
+			Header:        header,
+			Hash:          blockModel.Hash,
+			EcosystemID:   blockModel.EcosystemID,
+			NodePosition:  blockModel.NodePosition,
+			KeyID:         blockModel.KeyID,
+			Time:          blockModel.Time,
+			Tx:            blockModel.Tx,
+			RollbacksHash: blockModel.RollbacksHash,
+			MrklRoot:      blck.MrklRoot,
+			BinData:       blck.BinData,
+			SysUpdate:     blck.SysUpdate,
+			GenBlock:      blck.GenBlock,
+			StopCount:     blck.StopCount,
+			Transactions:  txDetailedInfoCollection,
+		}
+		result[blockModel.ID] = bdi
 	}
 
 	data.result = result

--- a/packages/api/route.go
+++ b/packages/api/route.go
@@ -92,6 +92,7 @@ func Route(route *hr.Router) {
 		get(`block/:id`, ``, getBlockInfo)
 		get(`maxblockid`, ``, getMaxBlockID)
 		get("blocks", "block_id ?count:int64", getBlocksTxInfo)
+		get("detailed_blocks", "block_id ?count:int64", getBlocksDetailedInfo)
 		get(`ecosystemparams`, `?ecosystem:int64,?names:string`, authWallet, ecosystemParams)
 		get(`systemparams`, `?names:string`, authWallet, systemParams)
 		get(`ecosystems`, ``, authWallet, ecosystems)

--- a/packages/transaction/transaction.go
+++ b/packages/transaction/transaction.go
@@ -263,6 +263,7 @@ func (t *Transaction) parseFromContract(buf *bytes.Buffer) error {
 	t.TxSmart = &smartTx
 	t.TxTime = smartTx.Time
 	t.TxKeyID = smartTx.KeyID
+	t.TxType = int64(smartTx.Type)
 
 	contract := smart.GetContractByID(int32(smartTx.Type))
 	if contract == nil {


### PR DESCRIPTION
Add mising TxType assignment in parseFromContract function.
Adapt TxInfo structure for JSON.
Add getBlocksDetailedInfo function to output more detailed block info.
Add /detailed_blocks API endpoint to call getBlocksDetailedInfo.
Add debug output to getBlockInfo, getBlocksTxInfo and getBlocksDetailedInfo functions.